### PR TITLE
support reading command as string instead of single character on termite

### DIFF
--- a/src/lab4a/main.c
+++ b/src/lab4a/main.c
@@ -37,17 +37,16 @@ int main(void) {
 	// Initialize UART -- change the argument depending on the part you are working on
 	Init_USARTx(2);
 	LED_Init();
-	char rxByte;
+	char command[64]; // assume command typed by the user is at most 63 characters (63 + 1 null character)
 	while(1) {
+		printf("Please enter a command:");
+		scanf("%s", command);
 		
-		printf("Please Enter a command:");
-		scanf("%c", &rxByte);
-
-		if((rxByte == 'Y') || (rxByte == 'y')){
+		if((strcmp(command, "Y") == 0) || (strcmp(command, "y") == 0)){
 			printf("LED ON \n");
 			Green_LED_On();
 		}
-		else if((rxByte == 'N') || (rxByte == 'n')){
+		else if((strcmp(command, "N") == 0) || (strcmp(command, "n") == 0)){
 			printf("LED OFF \n");
 			Green_LED_Off();
 		}


### PR DESCRIPTION
As described in the title, original code only accepts a single char in termite and would crash if you enter multiple characters.

I fixed this by allocating a size 64 char array to store the command the user inputs, then using the c builtin function strcmp() to compare the strings to either "Y"/"y"/"N"/"n"