### PR TITLE
optimize include headers

### DIFF
--- a/ece153b_lab.uvoptx
+++ b/ece153b_lab.uvoptx
@@ -1924,18 +1924,6 @@
     <File>
       <GroupNumber>14</GroupNumber>
       <FileNumber>123</FileNumber>
-      <FileType>5</FileType>
-      <tvExp>0</tvExp>
-      <tvExpOptDlg>0</tvExpOptDlg>
-      <bDave2>0</bDave2>
-      <PathWithFileName>.\src\final\camera.h</PathWithFileName>
-      <FilenameWithoutPath>camera.h</FilenameWithoutPath>
-      <RteFlg>0</RteFlg>
-      <bShared>0</bShared>
-    </File>
-    <File>
-      <GroupNumber>14</GroupNumber>
-      <FileNumber>124</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1947,7 +1935,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>125</FileNumber>
+      <FileNumber>124</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1959,7 +1947,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>126</FileNumber>
+      <FileNumber>125</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1971,7 +1959,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>127</FileNumber>
+      <FileNumber>126</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1983,7 +1971,7 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>128</FileNumber>
+      <FileNumber>127</FileNumber>
       <FileType>8</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
@@ -1995,13 +1983,25 @@
     </File>
     <File>
       <GroupNumber>14</GroupNumber>
-      <FileNumber>129</FileNumber>
+      <FileNumber>128</FileNumber>
       <FileType>5</FileType>
       <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>.\src\final\graphicstest.h</PathWithFileName>
       <FilenameWithoutPath>graphicstest.h</FilenameWithoutPath>
+      <RteFlg>0</RteFlg>
+      <bShared>0</bShared>
+    </File>
+    <File>
+      <GroupNumber>14</GroupNumber>
+      <FileNumber>129</FileNumber>
+      <FileType>5</FileType>
+      <tvExp>0</tvExp>
+      <tvExpOptDlg>0</tvExpOptDlg>
+      <bDave2>0</bDave2>
+      <PathWithFileName>.\src\final\nucleo.h</PathWithFileName>
+      <FilenameWithoutPath>nucleo.h</FilenameWithoutPath>
       <RteFlg>0</RteFlg>
       <bShared>0</bShared>
     </File>

--- a/ece153b_lab.uvprojx
+++ b/ece153b_lab.uvprojx
@@ -1957,11 +1957,6 @@
               <FilePath>.\src\final\UART_Bluetooth.h</FilePath>
             </File>
             <File>
-              <FileName>camera.h</FileName>
-              <FileType>5</FileType>
-              <FilePath>.\src\final\camera.h</FilePath>
-            </File>
-            <File>
               <FileName>UART_Wired.cpp</FileName>
               <FileType>8</FileType>
               <FilePath>.\src\final\UART_Wired.cpp</FilePath>
@@ -1990,6 +1985,11 @@
               <FileName>graphicstest.h</FileName>
               <FileType>5</FileType>
               <FilePath>.\src\final\graphicstest.h</FilePath>
+            </File>
+            <File>
+              <FileName>nucleo.h</FileName>
+              <FileType>5</FileType>
+              <FilePath>.\src\final\nucleo.h</FilePath>
             </File>
           </Files>
         </Group>

--- a/src/final/Adafruit_GFX.cpp
+++ b/src/final/Adafruit_GFX.cpp
@@ -31,7 +31,8 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <string.h>
+#include <stdint.h>
+// #include <string.h>
 #include <stdlib.h>
 
 #include "Adafruit_GFX.h"

--- a/src/final/Adafruit_GFX.h
+++ b/src/final/Adafruit_GFX.h
@@ -1,8 +1,6 @@
 #ifndef _ADAFRUIT_GFX_H
 #define _ADAFRUIT_GFX_H
 
-#include "stm32l476xx.h"
-
 // #if ARDUINO >= 100
 // #include "Arduino.h"
 #include "Print.h"

--- a/src/final/Adafruit_ILI9341.cpp
+++ b/src/final/Adafruit_ILI9341.cpp
@@ -46,9 +46,9 @@
  *
  */
 
-#include "SysTick.h"
-
 #include "Adafruit_ILI9341.h"
+
+#include "SysTick.h" // for delay()
 // // #ifndef ARDUINO_STM32_FEATHER
 // // #include "pins_arduino.h"
 // // #ifndef RASPI

--- a/src/final/Adafruit_ILI9341.h
+++ b/src/final/Adafruit_ILI9341.h
@@ -36,9 +36,9 @@
 #ifndef _ADAFRUIT_ILI9341H_
 #define _ADAFRUIT_ILI9341H_
 
-#include "SPI.h"
+// #include "SPI.h"
 
-#include "Adafruit_GFX.h"
+// #include "Adafruit_GFX.h"
 // #include "Arduino.h"
 // #include "Print.h"
 #include "Adafruit_SPITFT.h"

--- a/src/final/LED.h
+++ b/src/final/LED.h
@@ -1,7 +1,7 @@
 #ifndef __STM32L476R_NUCLEO_LED_H
 #define __STM32L476R_NUCLEO_LED_H
 
-#include "stm32l476xx.h"
+#include "nucleo.h"
 
 void init_LED(void);
 

--- a/src/final/Print.cpp
+++ b/src/final/Print.cpp
@@ -20,6 +20,7 @@
  Modified 03 August 2015 by Chuck Todd
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/final/Print.h
+++ b/src/final/Print.h
@@ -20,9 +20,10 @@
 #ifndef Print_h
 #define Print_h
 
-#include <inttypes.h>
+// #include <inttypes.h>
+#include <stdint.h>
 #include <stdio.h> // for size_t
-#include <string.h>
+#include <string.h> // strlen()
 
 // #include "WString.h"
 // #include "Printable.h"

--- a/src/final/SPI.h
+++ b/src/final/SPI.h
@@ -1,10 +1,7 @@
 #ifndef __STM32L476R_NUCLEO_SPI_H
 #define __STM32L476R_NUCLEO_SPI_H
 
-#include "camera.h"
-#include "stm32l476xx.h"
-
-#include <stddef.h>
+#include "nucleo.h"
 
 #define SPI_DEFAULT_FREQ 5000000 // equivalent to 80Mhz/16
 

--- a/src/final/SPI_Display.cpp
+++ b/src/final/SPI_Display.cpp
@@ -1,5 +1,4 @@
 #include "SPI_Display.h"
-#include "camera.h"
 
 SPI_Display::SPI_Display()
     : SPI(ILI9341) {}

--- a/src/final/SysClock.h
+++ b/src/final/SysClock.h
@@ -1,7 +1,7 @@
 #ifndef __STM32L476R_NUCLEO_CLOCK_H
 #define __STM32L476R_NUCLEO_CLOCK_H
 
-#include "stm32l476xx.h"
+#include "nucleo.h"
 
 void init_system_clock(void);
 

--- a/src/final/SysTick.h
+++ b/src/final/SysTick.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-#include "stm32l476xx.h"
+#include "nucleo.h"
 
 void init_SysTick(void);
 void SysTick_Handler(void);

--- a/src/final/UART.h
+++ b/src/final/UART.h
@@ -3,7 +3,7 @@
 
 #include "Print.h"
 
-#include "stm32l476xx.h"
+#include "nucleo.h"
 
 #define BufferSize 32
 #define UART_DEFAULT_BAUD_RATE 9600

--- a/src/final/UART_Bluetooth.cpp
+++ b/src/final/UART_Bluetooth.cpp
@@ -1,5 +1,4 @@
 #include "UART_Bluetooth.h"
-#include "camera.h"
 
 UART_Bluetooth::UART_Bluetooth()
     : UART(BLUETOOTH) {}

--- a/src/final/UART_Wired.cpp
+++ b/src/final/UART_Wired.cpp
@@ -1,5 +1,4 @@
 #include "UART_Wired.h"
-#include "camera.h"
 
 UART_Wired::UART_Wired()
     : UART(WIRED) {}

--- a/src/final/graphicstest.cpp
+++ b/src/final/graphicstest.cpp
@@ -16,11 +16,10 @@
 #include "graphicstest.h"
 
 // custom library
-#include "LED.h"
-#include "SysTick.h"
 #include "SysClock.h"
+#include "SysTick.h"
+#include "LED.h"
 #include "UART_Wired.h"
-#include "camera.h"
 
 // graphics and lcd library from Adafruit
 #include "Adafruit_GFX.h"

--- a/src/final/nucleo.h
+++ b/src/final/nucleo.h
@@ -1,9 +1,7 @@
 /*
-    This file contains various constants
-    hardware definitions, configuration parameters
+    This file contains various hardware definitions, 
+    constants, and comments describing hardware configuration
     specific to the digital_camera final project
-
-    For example, DEV_TERMINAL = WIRED = USART2
 */
 
 #ifndef __STM32L476R_NUCLEO_CAMERA_H
@@ -11,13 +9,13 @@
 
 #include "stm32l476xx.h"
 
+#include <stddef.h>
+
 #define CLK_FREQ  80000000 // 80Mhz
 
 #define BLUETOOTH USART1
 #define WIRED USART2
 #define ILI9341 SPI1
-
-#define DEV_TERMINAL WIRED
 
 
 /*


### PR DESCRIPTION
I've made a new header file called "nucelo.h" that stores various useful macros and comments documenting hardware config for our project. Use this header file to document which GPIO pins are used and to define various common aliases. nucelo.h imports stm32l476xx.h, so including nucelo.h will also import the register definitions as well.

Also cleaned up where header files are imported, following guidelines I found online. The guideline states: try to include headers in the source (c/c++) file only when necessary. Don't include other headers in the header file unless absolutely necessary.