### PR TITLE
Increase stack size

### DIFF
--- a/src/final/Adafruit_ImageReader.cpp
+++ b/src/final/Adafruit_ImageReader.cpp
@@ -326,8 +326,7 @@ ImageReturnCode Adafruit_ImageReader::coreBMP(
   uint32_t colors = 0;                       // Number of colors in palette
   uint16_t *quantized = NULL;                // 16-bit 5/6/5 color palette
   uint32_t rowSize;                          // >bmpWidth if scanline padding
-  // temporary fix for stack overflow (increase stack size or allocate in static memory)
-  static uint8_t sdbuf[3 * BUFPIXELS];       // BMP read buf (R+G+B/pixel)
+  uint8_t sdbuf[3 * BUFPIXELS];              // BMP read buf (R+G+B/pixel)
 #if ((3 * BUFPIXELS) <= 255)
   uint8_t srcidx = sizeof sdbuf; // Current position in sdbuf
 #else

--- a/src/final/startup_stm32l476xx.s
+++ b/src/final/startup_stm32l476xx.s
@@ -104,7 +104,7 @@
 ;******************** END ************************************************************************
 
 
-Stack_Size      EQU     0x400;
+Stack_Size      EQU     0x800;
 
                 AREA    STACK, NOINIT, READWRITE, ALIGN=3
 Stack_Mem       SPACE   Stack_Size


### PR DESCRIPTION
merge #134 before this

Double stack size to 8kB to allow image reader to work without using static global memory.