### PR TITLE
I2C Clock and Timing Setup/Adjustments

### DIFF
--- a/src/final/SysClock.cpp
+++ b/src/final/SysClock.cpp
@@ -102,7 +102,15 @@ void initSystemClock(void){
 
 	RCC->APB2ENR |= RCC_APB2ENR_SAI1EN;
 
-	//set sys clk as src for I2C1
+	//set APB1 (PCLK1) as src for I2C1 
 	RCC->CCIPR &= ~RCC_CCIPR_I2C1SEL;
-	RCC->CCIPR |=  RCC_CCIPR_I2C1SEL_0;
+	//RCC->CCIPR |=  RCC_CCIPR_I2C1SEL_0; 
+	
+	//[FIXED] refer to pg. 198 in STM32 manual for I2C1 clk src
+	/*
+	00: PCLK selected as I2C1 clock
+	01: System clock (SYSCLK) selected as I2C1 clock
+	10: HSI16 clock selected as I2C1 clock
+	11: reserved	
+	*/
 }

--- a/src/final/hardware_i2c1.cpp
+++ b/src/final/hardware_i2c1.cpp
@@ -30,6 +30,7 @@ void HardwareI2c1::configureGpio() {
 
 // initialize I2C following the flowchart on Figure 351 (pg 1107) of reference manual
 void HardwareI2c1::configureI2c() {
+	 //slave is 0x60 for write 0x61 for read
 	RCC->APB1ENR1 |= RCC_APB1ENR1_I2C1EN; // enable I2C1 clock
 	RCC->APB1RSTR1 |= RCC_APB1RSTR1_I2C1RST; // set, then reset to clear I2C1
 	RCC->APB1RSTR1 &= ~RCC_APB1RSTR1_I2C1RST;
@@ -40,38 +41,42 @@ void HardwareI2c1::configureI2c() {
 	I2Cx_->CR1 &= ~I2C_CR1_DNF; // disable digital noise filter
 
 	// [TODO] configure timings
-	// //2.a
-	// //enable error interrupts
-	// I2C1->CR1 |= I2C_CR1_ERRIE;	
+	/*
+	PPRE1[2:0]:APB low-speed prescaler (APB1) generated from HCLK or
+	Set and cleared by software to control the division factor of the APB1 clock (PCLK1).
+	0xx: HCLK not divided
+	100: HCLK divided by 2
+	101: HCLK divided by 4
+	110: HCLK divided by 8
+	111: HCLK divided by 16
+	*/
+	RCC->CFGR &= ~(RCC_CFGR_PPRE1);
+	RCC->CFGR |=  (RCC_CFGR_PPRE1_2 | RCC_CFGR_PPRE1_2);  //HCLK divided by 8
+	//not sure if should be done here, but it needs to be set
 
-	// //2.b
-	// /*
-	// Min Low clk per. = 4.7us
-	// Min Hi clk per. = 4.0us
-	// Min data setup time = 1000ns = 1us
-	// Min data hold time = 1250ns = 1.25us
+	// Min Low clk per. = 1.3us
+	// Min Hi clk per. = 600ns
+	// Min data setup time = 100ns 
+	// Min data hold time = 0us
+
+	//CPU clk (HCLK) = 80MHz/16= 5Mhz
+	//(f= 5Mhz then period of i2c clk) = t_i2cclk = 0.2us
 	
-	// PRESC = 7
-	// f_PRESC = 80MHz/(1+7) = 10MHz (t_PRESC = 0.1us)
+	//t_PRESC = (PRESC+1) x t_I2CCLK = (12+1)* 0.2us = 2.6us
+	// PRESC = 12
+	// f_PRESC = 5MHz/(12+1) = 0.384MHz = 384KHz (t_PRESC = 2.6us)
 	// SCLDEL = 0
-	// t_SCLDEL = (SCLDEL + 1) * t_PRESC = (10 + 1)*0.1us = 1.1us Condition: [t_SCLDEL > 1us] 
+	// t_SCLDEL = (SCLDEL + 1) * t_PRESC = (0 + 1)*2.6us = 2.6us  Condition: [t_SCLDEL(min data setup) > 1us] 
 	// SDADEL = 0
-	// t_SDADEL = (SDADEL + 1) * t_PRESC = (12 + 1)*0.1us = 1.3us	     	 [t_SDADEL > 1.25us]
-	// SCLL = 	0
-	// t_SCLL = (SCLL + 1) * t_PRESC = (47 + 1)*0.1us = 4.8us		         [t_SCLL > 4.7us]
-	// SCLH = 	0
-	// t_SCLH = (SCLH + 1) * t_PRESC = (40 + 1)*0.1us = 4.1us		         [t_SCLH > 4.0us]
+	// t_SDADEL = (SDADEL + 1) * t_PRESC = (0 + 1)*2.6us = 2.6us	     	 [t_SDADEL(min data hold) > 1.25us]
+	// SCLL = 	1
+	// t_SCLL = (SCLL + 1) * t_PRESC = (1 + 1)*2.6us = 5.2us		         [t_SCLL(min low clk per.) > 4.7us]
+	// SCLH = 	1
+	// t_SCLH = (SCLH + 1) * t_PRESC = (1 + 1)*2.6us = 5.2us		         [t_SCLH(min hi clk per.) > 4.0us]
 
-	
-	// */
-
-	// I2C1->TIMINGR |= ((7<<I2C_TIMINGR_PRESC_POS) 
-	// 				 |(10<<I2C_TIMINGR_SCLDEL_POS)
-	// 				 |(12<<I2C_TIMINGR_SDADEL_POS)
-	// 				 |(47<<I2C_TIMINGR_SCLH_POS)
-	// 				 |(40<<I2C_TIMINGR_SCLL_POS));
-
-	I2Cx_->CR1 &= ~I2C_CR1_NOSTRETCH; // enable clock stretching
-
-	I2Cx_->CR2 &= ~I2C_CR2_ADD10; // set to 7-bit addressing mode
+	I2C1->TIMINGR |= ((12<<I2C_TIMINGR_PRESC_POS) 
+					 |(0<<I2C_TIMINGR_SCLDEL_POS)
+					 |(0<<I2C_TIMINGR_SDADEL_POS)
+					 |(1<<I2C_TIMINGR_SCLH_POS)
+					 |(1<<I2C_TIMINGR_SCLL_POS));
 }


### PR DESCRIPTION
Configured clk source, setup and hold time, as well as min Low clk per.and min high clock per. for I2C. 

The clock source of I2C1 was set as APB1 or PCLK1, this clock matches the speed of the HCLK (CPU clk) which was set to 80Mhz. To adjust to a speed more managable for the camera sensor the clk was then divided by a prescaler value of 16 to achieve a speed of 5Mhz. 

Since the camera operates at 400Khz, I calculated the necessary timing in hardware_i2c1.cpp. Which was set in the i2c TIMINGR register. 