### PR TITLE
Potato Cam V1.0.1

### DIFF
--- a/src/final/Adafruit_ILI9341.h
+++ b/src/final/Adafruit_ILI9341.h
@@ -138,7 +138,7 @@ public:
   Adafruit_ILI9341();
 
   // methods
-  void begin(uint32_t freq = SPI_DEFAULT_FREQ);
+  void begin(uint32_t freq = SPI_MAX_FREQ);
   void setRotation(uint8_t r);
   void invertDisplay(bool i);
   void scrollTo(uint16_t y);

--- a/src/final/Adafruit_SPITFT.h
+++ b/src/final/Adafruit_SPITFT.h
@@ -156,7 +156,7 @@ public:
   // values defined in SPI.h, which are NOT the same as 0 for SPI_MODE0,
   // 1 for SPI_MODE1, etc...use ONLY the SPI_MODEn defines! Only!
   // Name is outdated (interface may be parallel) but for compatibility:
-  void initSPI(uint32_t freq = SPI_DEFAULT_FREQ);
+  void initSPI(uint32_t freq = SPI_MAX_FREQ);
   // void setSPISpeed(uint32_t freq);
   // Chip select and/or hardware SPI transaction start as needed:
   void startWrite(void);

--- a/src/final/Print.h
+++ b/src/final/Print.h
@@ -22,6 +22,7 @@
 
 #include <string.h> // strlen()
 #include <stdint.h>
+#include <stdio.h>
 
 #define DEC 10
 #define HEX 16

--- a/src/final/main.cpp
+++ b/src/final/main.cpp
@@ -10,6 +10,9 @@
 
 #include "potato.h"
 
+void setup(void);
+void loop(void);
+
 void initHardware() {
   initSystemClock();   // System Clock = 80 MHz
 	initSysTick();

--- a/src/final/potato.cpp
+++ b/src/final/potato.cpp
@@ -150,16 +150,15 @@ void saveImage(void) {
   Serial.println("Saving displayed image...");
 
   // Create a name for the new file in the format IMAGE_##.JPG
-  char filename[15];
-  strcpy(filename, "IMAGE_00.JPG");
-  for(int i = 0; i < 100; i++) {
-    filename[6] = '0' + i/10;
-    filename[7] = '0' + i%10;
+  char filename[20];
+  for(int i = 0; true; i++) {
+    sprintf(filename, "IMAGE_%d.JPG", i);
     if(!SD.exists(filename)) {
       break;
     }
   }
 
+  Serial.print("Opening "); Serial.print(filename); Serial.println("...");
   // create new image file in SD card
   File image_file = SD.open(filename, FILE_WRITE);
 

--- a/src/final/potato.cpp
+++ b/src/final/potato.cpp
@@ -143,7 +143,7 @@ bool tft_output(int16_t x, int16_t y, uint16_t w, uint16_t h, uint16_t* bitmap) 
 void drawImage(void) {
   // Draw the image, top left at 0,0
   TJpgDec.drawJpg(0, 0, image_buffer[buffer_index], image_size[buffer_index]);
-  Serial.println("Painted captured image");
+  Serial.println("Displayed captured image");
 }
 
 void saveImage(void) {

--- a/src/final/potato.h
+++ b/src/final/potato.h
@@ -10,8 +10,6 @@ extern "C" {
 
 extern volatile bool pending_save;
 
-void setup(void);
-void loop(void);
 bool captureImage(void);
 void drawImage(void);
 void saveImage(void);


### PR DESCRIPTION
- run display at max SPI freq of 40Mhz (instead of the default 2.5Mhz)
- fix some typo on console message
- allow infinite image names instead of 100